### PR TITLE
Add PDF conversion form with Bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+uploads/
+static/converted/
+.env

--- a/app.py
+++ b/app.py
@@ -1,10 +1,44 @@
-from flask import Flask
+from flask import Flask, render_template, request, url_for
+from datetime import datetime
+import os
+from modules.pdf_to_word import convert_pdf_to_word
+from modules.ocr_to_word import ocr_pdf_to_word
+
+UPLOAD_FOLDER = "uploads"
+CONVERTED_FOLDER = os.path.join("static", "converted")
+
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(CONVERTED_FOLDER, exist_ok=True)
 
 app = Flask(__name__)
 
-@app.route('/')
+
+@app.route("/", methods=["GET", "POST"])
 def home():
-    return "PDF to Word Converter - Kannada"
+    if request.method == "POST":
+        pdf_file = request.files.get("pdf")
+        title = request.form.get("title")
+        author = request.form.get("author")
+        pdf_type = request.form.get("pdf_type", "digital")
+
+        if pdf_file:
+            timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+            input_path = os.path.join(UPLOAD_FOLDER, f"{timestamp}_{pdf_file.filename}")
+            pdf_file.save(input_path)
+
+            output_filename = f"{timestamp}.docx"
+            output_path = os.path.join(CONVERTED_FOLDER, output_filename)
+
+            if pdf_type == "scanned":
+                ocr_pdf_to_word(input_path, output_path, title=title, author=author)
+            else:
+                convert_pdf_to_word(input_path, output_path, title=title, author=author)
+
+            download_link = url_for("static", filename=f"converted/{output_filename}")
+            return render_template("index.html", download_link=download_link)
+
+    return render_template("index.html")
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/modules/ocr_to_word.py
+++ b/modules/ocr_to_word.py
@@ -1,0 +1,28 @@
+from pdf2image import convert_from_path
+from docx import Document
+import pytesseract
+
+
+def ocr_pdf_to_word(
+    input_pdf_path: str,
+    output_docx_path: str,
+    *,
+    language: str = "kan",
+    title: str | None = None,
+    author: str | None = None,
+) -> str:
+    """Perform OCR on a scanned PDF and output a Word document."""
+
+    document = Document()
+    if title:
+        document.add_heading(title, level=1)
+    if author:
+        document.add_paragraph(f"Author: {author}")
+
+    images = convert_from_path(input_pdf_path)
+    for img in images:
+        text = pytesseract.image_to_string(img, lang=language)
+        document.add_paragraph(text)
+
+    document.save(output_docx_path)
+    return output_docx_path

--- a/modules/pdf_to_word.py
+++ b/modules/pdf_to_word.py
@@ -1,0 +1,26 @@
+from PyPDF2 import PdfReader
+from docx import Document
+
+
+def convert_pdf_to_word(
+    input_pdf_path: str,
+    output_docx_path: str,
+    *,
+    title: str | None = None,
+    author: str | None = None,
+) -> str:
+    """Convert a digital PDF file to a Word document."""
+
+    document = Document()
+    if title:
+        document.add_heading(title, level=1)
+    if author:
+        document.add_paragraph(f"Author: {author}")
+
+    reader = PdfReader(input_pdf_path)
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        document.add_paragraph(text)
+
+    document.save(output_docx_path)
+    return output_docx_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-flask
+Flask
+PyPDF2
+python-docx
+pdf2image
+pytesseract

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,39 @@
 <!DOCTYPE html>
 <html>
-<head><title>Kannada PDF to Word</title></head>
-<body>
-    <h1>Upload Kannada PDF</h1>
-    <form method="POST" enctype="multipart/form-data">
-        <input type="file" name="pdf">
-        <button type="submit">Convert</button>
+<head>
+    <meta charset="utf-8">
+    <title>Kannada PDF to Word</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+    <h1 class="mb-4 text-center">ಕನ್ನಡ PDF to Word</h1>
+    <form method="POST" enctype="multipart/form-data" class="mb-3">
+        <div class="mb-3">
+            <label class="form-label">ಶೀರ್ಷಿಕೆ</label>
+            <input type="text" name="title" class="form-control" placeholder="ಶೀರ್ಷಿಕೆ">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">ಲೇಖಕ</label>
+            <input type="text" name="author" class="form-control" placeholder="ಲೇಖಕ">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">PDF ಪ್ರಕಾರ</label>
+            <select name="pdf_type" class="form-select">
+                <option value="digital">ಡಿಜಿಟಲ್</option>
+                <option value="scanned">ಸ್ಕ್ಯಾನ್</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">ಕನ್ನಡ PDF</label>
+            <input type="file" name="pdf" class="form-control">
+        </div>
+        <button type="submit" class="btn btn-primary">ರೂಪಾಂತರಿಸಿ</button>
     </form>
+
+    {% if download_link %}
+    <div class="alert alert-success">
+        <a href="{{ download_link }}">ವರ್ಡ್ ಫೈಲ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</a>
+    </div>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build a minimal Flask app for converting PDFs to Word docs
- add helper modules for PDF parsing and OCR
- use Bootstrap layout for upload form with Kannada labels and placeholders
- expose a download link after conversion
- track Python modules and ignore runtime paths

## Testing
- `ruff check app.py modules/*.py`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6887674945dc8332a392b98ff68d378c