### PR TITLE
Handle invalid PDFs gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Then open [http://localhost:5000](http://localhost:5000) in your browser. Use th
   app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024
   ```
 - **Cleanup**: Temporary files created during conversion (such as intermediate images) should be removed after use to avoid filling the disk. Modify the conversion scripts in `modules/` to delete any files they create once conversion is completed.
+- **Error handling**: If a corrupt or invalid PDF is uploaded, the application will report an error instead of crashing.
 
 ## Obtaining the `.txt` file
 

--- a/app.py
+++ b/app.py
@@ -36,10 +36,13 @@ def home():
             output_filename = f"{timestamp}.docx"
             output_path = os.path.join(CONVERTED_FOLDER, output_filename)
 
-            if pdf_type == "scanned":
-                ocr_pdf_to_word(input_path, output_path, title=title, author=author)
-            else:
-                convert_pdf_to_word(input_path, output_path, title=title, author=author)
+            try:
+                if pdf_type == "scanned":
+                    ocr_pdf_to_word(input_path, output_path, title=title, author=author)
+                else:
+                    convert_pdf_to_word(input_path, output_path, title=title, author=author)
+            except ValueError as e:
+                return render_template("index.html", error=str(e))
 
             download_link = url_for("static", filename=f"converted/{output_filename}")
             return render_template("index.html", download_link=download_link)

--- a/modules/pdf_to_word.py
+++ b/modules/pdf_to_word.py
@@ -1,4 +1,5 @@
 from PyPDF2 import PdfReader
+from PyPDF2.errors import PdfReadError
 from docx import Document
 
 
@@ -17,7 +18,10 @@ def convert_pdf_to_word(
     if author:
         document.add_paragraph(f"Author: {author}")
 
-    reader = PdfReader(input_pdf_path)
+    try:
+        reader = PdfReader(input_pdf_path, strict=False)
+    except PdfReadError as exc:
+        raise ValueError("Uploaded file is not a valid PDF.") from exc
     for page in reader.pages:
         text = page.extract_text() or ""
         document.add_paragraph(text)

--- a/static/style.css
+++ b/static/style.css
@@ -24,3 +24,8 @@ body {
 #download-section {
     margin-top: 20px;
 }
+
+.error {
+    color: red;
+    margin-top: 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,17 @@
 </head>
 <body>
     <h1>Upload Kannada PDF</h1>
+    {% if error %}
+    <p class="error">{{ error }}</p>
+    {% endif %}
     <form method="POST" enctype="multipart/form-data" class="upload-form">
         <input type="file" name="pdf">
         <button type="submit" class="convert-btn">Convert</button>
     </form>
-    <div id="download-section"></div>
+    <div id="download-section">
+        {% if download_link %}
+        <a href="{{ download_link }}">Download Word File</a>
+        {% endif %}
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add friendly PDF error handling in `convert_pdf_to_word`
- display error messages in the UI
- catch `ValueError` in `home` route
- style error messages
- document corrupt PDF handling

## Testing
- `python -m py_compile modules/pdf_to_word.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ba8e62c88332b11f44e26b98f4ac