### PR TITLE
Add Poppler installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ This project is a simple Flask web application that converts Kannada PDF files t
    pip install google-cloud-vision
    ```
 
+3. **Install Poppler**
+   The `pdf2image` package relies on Poppler's command-line tools.
+   Install them with your system package manager or from the project website:
+   - macOS: `brew install poppler`
+   - Ubuntu/Debian: `sudo apt-get install poppler-utils`
+   - Windows: download the Poppler binaries and add them to your `PATH`.
+
 ## Setting up Google Cloud Vision credentials
 
 1. Create a project on Google Cloud Platform and enable the **Vision API**.


### PR DESCRIPTION
## Summary
- explain that pdf2image depends on Poppler
- provide install examples for macOS, Ubuntu/Debian and Windows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68885ac5e66c8332bb1c767c1c44ebcb