### PR TITLE
Add legacy Kannada conversion support

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,11 @@
-from . import pdf_to_word, ocr_to_word
+"""Utility modules for Kannada text processing."""
+
+__all__ = ["pdf_to_word", "ocr_to_word", "legacy_kannada"]
+
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/modules/legacy_kannada.py
+++ b/modules/legacy_kannada.py
@@ -1,0 +1,17 @@
+"""Simple legacy Kannada to Unicode converter."""
+
+LEGACY_TO_UNICODE = {
+    "AiÀÄ": "ಆ",  # Example mapping from Nudi legacy encoding
+    "ªÀ": "ಅ",
+    "£À": "ನ",
+    "PÀ": "ಡ",
+}
+
+
+def convert_legacy_to_unicode(text: str) -> str:
+    """Convert legacy Kannada text (e.g., Nudi/KGP) to Unicode."""
+    result = text
+    # replace longer sequences first
+    for legacy, uni in sorted(LEGACY_TO_UNICODE.items(), key=lambda x: -len(x[0])):
+        result = result.replace(legacy, uni)
+    return result

--- a/modules/pdf_to_word.py
+++ b/modules/pdf_to_word.py
@@ -1,6 +1,7 @@
 from PyPDF2 import PdfReader
 from PyPDF2.errors import PdfReadError
 from docx import Document
+from .legacy_kannada import convert_legacy_to_unicode
 
 
 def convert_pdf_to_word(
@@ -24,6 +25,7 @@ def convert_pdf_to_word(
         raise ValueError("Uploaded file is not a valid PDF.") from exc
     for page in reader.pages:
         text = page.extract_text() or ""
+        text = convert_legacy_to_unicode(text)
         document.add_paragraph(text)
 
     document.save(output_docx_path)

--- a/tests/test_legacy_kannada.py
+++ b/tests/test_legacy_kannada.py
@@ -1,0 +1,11 @@
+import unittest
+from modules.legacy_kannada import convert_legacy_to_unicode
+
+class TestLegacyKannada(unittest.TestCase):
+    def test_simple_conversion(self):
+        legacy_text = "ªÀ£ÀPÀAiÀÄ"
+        expected = "ಅನಡಆ"
+        self.assertEqual(convert_legacy_to_unicode(legacy_text), expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add simple legacy Kannada converter
- update PDF conversion to apply legacy mapping
- support lazy submodule loading
- test legacy conversion example

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885cf6dc988332aca6370646f74c6a