### PR TITLE
Add hybrid OCR using Google Vision

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import os
 from modules.pdf_to_word import convert_pdf_to_word
 from modules.ocr_to_word import ocr_pdf_to_word
+from dotenv import load_dotenv
 
 UPLOAD_FOLDER = "uploads"
 CONVERTED_FOLDER = os.path.join("static", "converted")
@@ -18,6 +19,9 @@ app.secret_key = 'secret-key'
 
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
+# Load environment variables (e.g., Google credentials)
+load_dotenv()
+
 
 
 @app.route("/", methods=["GET", "POST"])
@@ -27,6 +31,7 @@ def home():
         title = request.form.get("title")
         author = request.form.get("author")
         pdf_type = request.form.get("pdf_type", "digital")
+        use_google = request.form.get("use_google") == "on"
 
         if pdf_file:
             timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -38,11 +43,21 @@ def home():
 
             try:
                 if pdf_type == "scanned":
-                    ocr_pdf_to_word(input_path, output_path, title=title, author=author)
+                    ocr_pdf_to_word(
+                        input_path,
+                        output_path,
+                        title=title,
+                        author=author,
+                        use_google=use_google,
+                    )
                 else:
                     convert_pdf_to_word(input_path, output_path, title=title, author=author)
             except ValueError as e:
                 return render_template("index.html", error=str(e))
+            finally:
+                # remove uploaded file after processing
+                if os.path.exists(input_path):
+                    os.remove(input_path)
 
             download_link = url_for("static", filename=f"converted/{output_filename}")
             return render_template("index.html", download_link=download_link)

--- a/modules/ocr_to_word.py
+++ b/modules/ocr_to_word.py
@@ -1,6 +1,18 @@
 from pdf2image import convert_from_path
 from docx import Document
 import pytesseract
+from google.cloud import vision
+from PIL import ImageOps
+from tempfile import TemporaryDirectory
+import io
+
+
+def _preprocess_image(img):
+    """Convert image to grayscale and apply binary threshold."""
+    gray = ImageOps.grayscale(img)
+    # Simple threshold at mid-range; works well for most scanned docs
+    bw = gray.point(lambda x: 0 if x < 128 else 255, "1")
+    return bw.convert("L")
 
 
 def ocr_pdf_to_word(
@@ -10,8 +22,25 @@ def ocr_pdf_to_word(
     language: str = "kan",
     title: str | None = None,
     author: str | None = None,
+    use_google: bool = False,
+    vision_page_limit: int | None = None,
 ) -> str:
-    """Perform OCR on a scanned PDF and output a Word document."""
+    """Perform OCR on a scanned PDF and output a Word document.
+
+    Parameters
+    ----------
+    input_pdf_path: str
+        Path to the scanned PDF file.
+    output_docx_path: str
+        Where to store the generated Word file.
+    language: str
+        Language code for OCR (defaults to Kannada).
+    title, author: Optional metadata stored in the Word file.
+    use_google: bool
+        If ``True`` use Google Cloud Vision for OCR. Otherwise use Tesseract.
+    vision_page_limit: int, optional
+        Limit Vision OCR to the first ``vision_page_limit`` pages.
+    """
 
     document = Document()
     if title:
@@ -19,10 +48,30 @@ def ocr_pdf_to_word(
     if author:
         document.add_paragraph(f"Author: {author}")
 
-    images = convert_from_path(input_pdf_path)
-    for img in images:
-        text = pytesseract.image_to_string(img, lang=language)
-        document.add_paragraph(text)
+    with TemporaryDirectory() as temp_dir:
+        images = convert_from_path(input_pdf_path, output_folder=temp_dir, fmt="png")
+
+        if use_google:
+            client = vision.ImageAnnotatorClient()
+
+        for page_num, img in enumerate(images, start=1):
+            processed = _preprocess_image(img)
+
+            if use_google and (vision_page_limit is None or page_num <= vision_page_limit):
+                buffer = io.BytesIO()
+                processed.save(buffer, format="PNG")
+                g_image = vision.Image(content=buffer.getvalue())
+                response = client.document_text_detection(
+                    image=g_image,
+                    image_context={"language_hints": [language]},
+                )
+                text = response.full_text_annotation.text if response.full_text_annotation else ""
+            else:
+                text = pytesseract.image_to_string(processed, lang=language)
+
+            document.add_paragraph(text)
+            if page_num < len(images):
+                document.add_page_break()
 
     document.save(output_docx_path)
     return output_docx_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ google-cloud-vision
 python-docx
 pytesseract
 opencv-python-headless
+python-dotenv
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,9 @@
             <label><input type="radio" name="pdf_type" value="digital" checked> Digital</label>
             <label><input type="radio" name="pdf_type" value="scanned"> Scanned</label>
         </div>
+        <div class="pdf-type">
+            <label><input type="checkbox" name="use_google"> ಉನ್ನತ ಖಚಿತ್ತೆ OCR (Google Vision)</label>
+        </div>
         <button type="submit" class="convert-btn">Convert</button>
     </form>
     {% if download_link %}


### PR DESCRIPTION
## Summary
- support Tesseract or Google Vision OCR in `ocr_pdf_to_word`
- allow Vision OCR toggle and optional page limit
- expose Google Vision option in the Flask form
- load `.env` for credentials
- clean up uploaded files
- add `python-dotenv` to requirements

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886ad5a7688332a164c2f84d373e08