### PR TITLE
Add force OCR option

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ def home():
         author = request.form.get("author", "").strip()
         pdf_type = request.form.get("pdf_type", "digital")
         use_google = request.form.get("use_google") == "on"
+        force_ocr = request.form.get("force_ocr") == "on"
 
         # Validate file
         is_valid, error_msg = validate_pdf_file(pdf_file)
@@ -129,6 +130,7 @@ def home():
                     txt_path,
                     title=title or None,
                     author=author or None,
+                    force_ocr=force_ocr,
                 )
                 
                 # Validate digital PDF results

--- a/modules/pdf_to_word.py
+++ b/modules/pdf_to_word.py
@@ -17,6 +17,7 @@ from .legacy_kannada import (
     normalize_unicode,
     is_kannada_text
 )
+from .ocr_to_word import ocr_pdf_to_word
 
 # ...rest of existing code...
 
@@ -168,6 +169,7 @@ def convert_pdf_to_word(
     *,
     title: str | None = None,
     author: str | None = None,
+    force_ocr: bool = False,
 ) -> tuple[str, str]:
     """Convert a digital PDF file to a Word document with enhanced Kannada support."""
 
@@ -185,6 +187,16 @@ def convert_pdf_to_word(
     if author:
         core.author = author
     core.language = "kn-IN"  # Kannada locale
+
+    if force_ocr:
+        logger.info("Force OCR enabled - using OCR pipeline")
+        return ocr_pdf_to_word(
+            input_pdf_path,
+            output_docx_path,
+            output_txt_path,
+            title=title,
+            author=author,
+        )
 
     # Check for legacy fonts
     has_legacy_fonts = _detect_legacy_fonts_in_pdf(input_pdf_path)

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,9 @@
         <div class="pdf-type">
             <label><input type="checkbox" name="use_google"> ಉನ್ನತ ಖಚಿತತೆ OCR (Google Vision)</label>
         </div>
+        <div class="pdf-type">
+            <label><input type="checkbox" name="force_ocr"> ಪಠ್ಯ ಓದಲು ಸಾಧ್ಯವಾಗದಿದ್ದರೆ OCR ಬಳಸಿ</label>
+        </div>
         <button type="submit" class="convert-btn">Convert</button>
     </form>
     {% if download_docx %}


### PR DESCRIPTION
## Summary
- add a checkbox on the upload form for forcing OCR
- propagate the flag in `app.py`
- call the OCR pipeline directly from `convert_pdf_to_word` when forced

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688895a69cd08332bd7df9d3ef8fc98c