### PR TITLE
Add OCR converter and update dependencies

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,6 +1,11 @@
 """Utility modules for Kannada text processing."""
 
-__all__ = ["pdf_to_word", "ocr_to_word", "legacy_kannada"]
+__all__ = [
+    "pdf_to_word",
+    "ocr_to_word",
+    "legacy_kannada",
+    "simple_pdf_converter",
+]
 
 from importlib import import_module
 

--- a/modules/ocr_to_word.py
+++ b/modules/ocr_to_word.py
@@ -21,7 +21,7 @@ from .legacy_kannada import (
     detect_legacy_encoding,
     validate_kannada_output,
     normalize_unicode,
-    is_kannada_text
+    is_kannada_text,
 )
 from .kannada_image_preprocessor import preprocess_kannada_image
 
@@ -29,65 +29,70 @@ from .kannada_image_preprocessor import preprocess_kannada_image
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def _preprocess_image_for_kannada(img):
     """Enhanced preprocessing specifically optimized for Kannada OCR using new pipeline."""
     logger.debug("Starting enhanced Kannada image preprocessing")
-    
+
     try:
         # Use the new advanced preprocessing pipeline
         processed_array = preprocess_kannada_image(img)
-        
+
         # Convert back to PIL Image for OCR compatibility
         processed_img = Image.fromarray(processed_array)
-        
+
         logger.debug("Enhanced preprocessing completed successfully")
         return processed_img
-        
+
     except Exception as e:
         logger.error(f"Enhanced preprocessing failed, using fallback: {e}")
-        
+
         # Fallback to simple preprocessing if new pipeline fails
         try:
             # Convert PIL to OpenCV format
             opencv_img = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
-            
+
             # Convert to grayscale
             gray = cv2.cvtColor(opencv_img, cv2.COLOR_BGR2GRAY)
-            
+
             # Simple enhancement
-            clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8,8))
+            clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
             enhanced = clahe.apply(gray)
-            
+
             # Basic thresholding
-            _, binary = cv2.threshold(enhanced, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
-            
+            _, binary = cv2.threshold(
+                enhanced, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+            )
+
             return Image.fromarray(binary)
-            
+
         except Exception as e2:
             logger.error(f"Fallback preprocessing also failed: {e2}")
             # Return original image if all preprocessing fails
             return img
 
-def _perform_tesseract_ocr(image, language: str = "kan", timeout: Optional[int] = 30) -> str:
+
+def _perform_tesseract_ocr(
+    image, language: str = "kan", timeout: Optional[int] = 30
+) -> str:
     """Perform Tesseract OCR with Kannada-specific configuration."""
     try:
         logger.debug("Starting Tesseract OCR")
         start_time = time.time()
-        
+
         # Enhanced Tesseract configuration for Kannada magazines
-        custom_config = r'--oem 3 --psm 6 -c tessedit_char_whitelist=ಅ-ೞ೦-೯ -c preserve_interword_spaces=1'
-        
+        custom_config = r"--oem 3 --psm 6 -c tessedit_char_whitelist=ಅ-ೞ೦-೯ -c preserve_interword_spaces=1"
+
         # First attempt with Kannada whitelist and preserve spaces
         text = pytesseract.image_to_string(
-            image, 
-            lang=language,
-            config=custom_config,
-            timeout=timeout
+            image, lang=language, config=custom_config, timeout=timeout
         )
-        
+
         elapsed = time.time() - start_time
-        logger.debug(f"Tesseract OCR completed in {elapsed:.2f}s, extracted {len(text)} characters")
-        
+        logger.debug(
+            f"Tesseract OCR completed in {elapsed:.2f}s, extracted {len(text)} characters"
+        )
+
         # If no text found, try alternative configurations
         if not text.strip():
             logger.warning("No text with whitelist, trying without restrictions")
@@ -95,12 +100,12 @@ def _perform_tesseract_ocr(image, language: str = "kan", timeout: Optional[int] 
                 text = pytesseract.image_to_string(
                     image,
                     lang=language,
-                    config=r'--oem 3 --psm 6 -c preserve_interword_spaces=1',
-                    timeout=timeout//2
+                    config=r"--oem 3 --psm 6 -c preserve_interword_spaces=1",
+                    timeout=timeout // 2,
                 )
             except Exception as e:
                 logger.warning(f"Fallback OCR failed: {e}")
-        
+
         # If still no text, try different PSM modes
         if not text.strip():
             logger.warning("Trying alternative PSM modes")
@@ -109,88 +114,100 @@ def _perform_tesseract_ocr(image, language: str = "kan", timeout: Optional[int] 
                     text = pytesseract.image_to_string(
                         image,
                         lang=language,
-                        config=f'--oem 3 --psm {psm} -c preserve_interword_spaces=1',
-                        timeout=15
+                        config=f"--oem 3 --psm {psm} -c preserve_interword_spaces=1",
+                        timeout=15,
                     )
                     if text.strip():
                         logger.info(f"Success with PSM mode {psm}")
                         break
                 except Exception:
                     continue
-        
+
         return text
-        
+
     except pytesseract.TesseractError as e:
         if "timeout" in str(e).lower():
             logger.error(f"Tesseract OCR timed out after {timeout} seconds")
-            raise TimeoutError(f"Tesseract OCR timed out after {timeout} seconds") from e
+            raise TimeoutError(
+                f"Tesseract OCR timed out after {timeout} seconds"
+            ) from e
         logger.error(f"Tesseract OCR error: {e}")
         return ""
     except Exception as e:
         logger.error(f"Tesseract OCR failed: {e}")
         return ""
 
-def _perform_google_vision_ocr(image, language: str = "kan", timeout: Optional[int] = 30) -> str:
+
+def _perform_google_vision_ocr(
+    image, language: str = "kan", timeout: Optional[int] = 30
+) -> str:
     """Perform Google Vision OCR with enhanced Kannada optimization."""
     try:
         logger.debug("Starting Google Vision OCR")
         start_time = time.time()
-        
+
         client = vision.ImageAnnotatorClient()
-        
+
         # Convert image to bytes with optimized compression
         buffer = io.BytesIO()
-        image.save(buffer, format="PNG", optimize=False, compress_level=1)  # Fast compression
+        image.save(
+            buffer, format="PNG", optimize=False, compress_level=1
+        )  # Fast compression
         buffer.seek(0)
-        
+
         # Create Vision API image object
         vision_image = vision.Image(content=buffer.getvalue())
-        
+
         # Enhanced image context for better Kannada recognition
         image_context = vision.ImageContext(
-            language_hints=['kn', 'en'],  # Use proper language codes
+            language_hints=["kn", "en"],  # Use proper language codes
             text_detection_params=vision.TextDetectionParams(
                 enable_text_detection_confidence_score=True,
                 advanced_ocr_options=[
                     vision.TextDetectionParams.AdvancedOcrOption.LEGACY_LAYOUT
-                ]
-            )
+                ],
+            ),
         )
-        
+
         # Use document_text_detection for better layout preservation
         response = client.document_text_detection(
-            image=vision_image,
-            image_context=image_context,
-            timeout=timeout
+            image=vision_image, image_context=image_context, timeout=timeout
         )
-        
+
         if response.error.message:
             raise Exception(f"Google Vision API error: {response.error.message}")
-        
-        text = response.full_text_annotation.text if response.full_text_annotation else ""
-        
+
+        text = (
+            response.full_text_annotation.text if response.full_text_annotation else ""
+        )
+
         elapsed = time.time() - start_time
-        logger.debug(f"Google Vision OCR completed in {elapsed:.2f}s, extracted {len(text)} characters")
-        
+        logger.debug(
+            f"Google Vision OCR completed in {elapsed:.2f}s, extracted {len(text)} characters"
+        )
+
         # Log sample of extracted text for debugging
         if text:
-            sample = text[:100].replace('\n', ' ')
+            sample = text[:100].replace("\n", " ")
             logger.debug(f"Sample Google Vision text: {sample}")
-        
+
         return text
-        
+
     except Exception as e:
         if "deadline exceeded" in str(e).lower() or "timeout" in str(e).lower():
             logger.error(f"Google Vision OCR timed out after {timeout} seconds")
-            raise TimeoutError(f"Google Vision OCR timed out after {timeout} seconds") from e
+            raise TimeoutError(
+                f"Google Vision OCR timed out after {timeout} seconds"
+            ) from e
         logger.error(f"Google Vision OCR failed: {e}")
         return ""
+
 
 def _check_tesseract_kannada():
     """Check if Tesseract has Kannada language support installed."""
     try:
         available_langs = pytesseract.get_languages()
-        if 'kan' not in available_langs:
+        if "kan" not in available_langs:
             logger.warning("Kannada language pack not found in Tesseract")
             logger.info("Available languages: " + ", ".join(available_langs))
             return False
@@ -200,13 +217,14 @@ def _check_tesseract_kannada():
         logger.error(f"Cannot check Tesseract languages: {e}")
         return False
 
+
 def _process_ocr_text(text, is_legacy_detected=False, debug_mode=False):
     """Process OCR output with Kannada-specific corrections."""
     if not text.strip():
         return ""
-    
+
     logger.debug(f"Processing OCR text: {len(text)} characters")
-    
+
     try:
         if debug_mode:
             # DEBUG MODE: Skip legacy processing to see raw OCR quality
@@ -215,28 +233,30 @@ def _process_ocr_text(text, is_legacy_detected=False, debug_mode=False):
         else:
             # Apply legacy conversion if needed
             processed = post_process_kannada_text(text, is_legacy=is_legacy_detected)
-        
+
         # Validate output quality
         is_valid, issues = validate_kannada_output(processed)
         if not is_valid:
             logger.warning(f"OCR quality issues detected: {', '.join(issues)}")
-        
+
         logger.debug(f"Processed text: {len(processed)} characters")
         return processed
-        
+
     except Exception as e:
         logger.error(f"Text processing failed: {e}")
         return text  # Return original if processing fails
 
+
 def _set_kannada_font(run):
     """Set appropriate font for Kannada text rendering."""
     try:
-        run.font.name = 'Noto Sans Kannada'
+        run.font.name = "Noto Sans Kannada"
         # Fallback fonts for better compatibility
-        run._element.rPr.rFonts.set(qn('w:eastAsia'), 'Noto Sans Kannada')
-        run._element.rPr.rFonts.set(qn('w:cs'), 'Noto Sans Kannada')
+        run._element.rPr.rFonts.set(qn("w:eastAsia"), "Noto Sans Kannada")
+        run._element.rPr.rFonts.set(qn("w:cs"), "Noto Sans Kannada")
     except Exception as e:
         logger.warning(f"Could not set Kannada font: {e}")
+
 
 def ocr_pdf_to_word(
     input_pdf_path: str,
@@ -252,24 +272,26 @@ def ocr_pdf_to_word(
     debug_mode: bool = False,
 ) -> tuple[str, str]:
     """Perform OCR on a scanned PDF and output a Word document."""
-    
+
     logger.info(f"Starting OCR conversion: {input_pdf_path}")
-    logger.info(f"Settings: use_google={use_google}, vision_page_limit={vision_page_limit}, timeout={ocr_timeout}")
-    
+    logger.info(
+        f"Settings: use_google={use_google}, vision_page_limit={vision_page_limit}, timeout={ocr_timeout}"
+    )
+
     # Validate Tesseract setup for Kannada
     if not use_google and not _check_tesseract_kannada():
         raise RuntimeError(
             "Tesseract Kannada language pack not found. "
             "Install with: brew install tesseract-lang"
         )
-    
+
     # Initialize document
     document = Document()
-    
+
     # Set up output paths
     if output_txt_path is None:
         output_txt_path = os.path.splitext(output_docx_path)[0] + ".txt"
-    
+
     # Set document metadata
     core = document.core_properties
     if title:
@@ -277,33 +299,33 @@ def ocr_pdf_to_word(
     if author:
         core.author = author
     core.language = "kn-IN"  # Kannada locale
-    
+
     full_text = ""
     total_pages = 0
     processed_pages = 0
     successful_pages = 0
-    
+
     try:
         with TemporaryDirectory() as temp_dir:
             # Convert PDF to images with lower DPI for speed
             logger.info(f"Converting PDF to images")
             try:
                 images = convert_from_path(
-                    input_pdf_path, 
-                    output_folder=temp_dir, 
+                    input_pdf_path,
+                    output_folder=temp_dir,
                     fmt="png",
                     dpi=200,  # Reduced DPI for faster processing
                     thread_count=1,  # Single thread to avoid memory issues
                     first_page=1,
-                    last_page=None  # Process all pages
+                    last_page=None,  # Process all pages
                 )
             except Exception as e:
                 logger.error(f"Failed to convert PDF to images: {e}")
                 raise RuntimeError(f"Failed to convert PDF to images: {e}")
-            
+
             total_pages = len(images)
             logger.info(f"Successfully converted {total_pages} pages to images")
-            
+
             # Initialize Google Vision client if needed
             if use_google:
                 try:
@@ -313,113 +335,140 @@ def ocr_pdf_to_word(
                     logger.error(f"Failed to initialize Google Vision: {e}")
                     use_google = False
                     logger.info("Falling back to Tesseract")
-            
+
             for page_num, img in enumerate(images, start=1):
                 logger.info(f"Processing page {page_num}/{total_pages}")
                 processed_pages += 1
                 page_text = ""
-                
+
                 try:
                     # Preprocess image for better OCR
                     processed_img = _preprocess_image_for_kannada(img)
-                    
+
                     # Determine OCR method
-                    use_vision_for_page = (
-                        use_google and 
-                        (vision_page_limit is None or page_num <= vision_page_limit)
+                    use_vision_for_page = use_google and (
+                        vision_page_limit is None or page_num <= vision_page_limit
                     )
-                    
+
                     # Perform OCR with error handling
                     if use_vision_for_page:
                         logger.info(f"Using Google Vision for page {page_num}")
                         try:
-                            page_text = _perform_google_vision_ocr(processed_img, language, timeout=ocr_timeout)
+                            page_text = _perform_google_vision_ocr(
+                                processed_img, language, timeout=ocr_timeout
+                            )
                         except TimeoutError:
-                            logger.warning(f"Google Vision timeout on page {page_num}, falling back to Tesseract")
-                            page_text = _perform_tesseract_ocr(processed_img, language, timeout=ocr_timeout//2)
+                            logger.warning(
+                                f"Google Vision timeout on page {page_num}, falling back to Tesseract"
+                            )
+                            page_text = _perform_tesseract_ocr(
+                                processed_img, language, timeout=ocr_timeout // 2
+                            )
                         except Exception as e:
-                            logger.error(f"Google Vision failed on page {page_num}, falling back to Tesseract: {e}")
-                            page_text = _perform_tesseract_ocr(processed_img, language, timeout=ocr_timeout//2)
+                            logger.error(
+                                f"Google Vision failed on page {page_num}, falling back to Tesseract: {e}"
+                            )
+                            page_text = _perform_tesseract_ocr(
+                                processed_img, language, timeout=ocr_timeout // 2
+                            )
                     else:
                         logger.info(f"Using Tesseract for page {page_num}")
-                        page_text = _perform_tesseract_ocr(processed_img, language, timeout=ocr_timeout)
-                    
+                        page_text = _perform_tesseract_ocr(
+                            processed_img, language, timeout=ocr_timeout
+                        )
+
                     # DEBUG: Log raw OCR output
-                    logger.info(f"Raw OCR output for page {page_num}: '{page_text[:200]}...'")
-                    
+                    logger.info(
+                        f"Raw OCR output for page {page_num}: '{page_text[:200]}...'"
+                    )
+
                     # Detect legacy encoding
                     is_legacy = detect_legacy_encoding(page_text)
-                    logger.info(f"Legacy encoding detected on page {page_num}: {is_legacy}")
-                    
+                    logger.info(
+                        f"Legacy encoding detected on page {page_num}: {is_legacy}"
+                    )
+
                     # DEBUG: Log before and after processing
                     logger.info(f"Before processing: '{page_text[:100]}...'")
-                    cleaned_text = _process_ocr_text(page_text, is_legacy, debug_mode=debug_mode)
+                    cleaned_text = _process_ocr_text(
+                        page_text, is_legacy, debug_mode=debug_mode
+                    )
                     logger.info(f"After processing: '{cleaned_text[:100]}...'")
-                    
+
                     # DEBUG: Check if processing made it worse
                     if len(page_text) > 0 and len(cleaned_text) < len(page_text) * 0.1:
-                        logger.warning(f"Processing reduced text from {len(page_text)} to {len(cleaned_text)} chars - possible over-cleaning")
-                    
+                        logger.warning(
+                            f"Processing reduced text from {len(page_text)} to {len(cleaned_text)} chars - possible over-cleaning"
+                        )
+
                     # Add page content to document
                     # Add page header
                     page_header = document.add_paragraph(f"ಪುಟ {page_num}")
                     page_header.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
-                    page_header.style = 'Heading 2'
+                    page_header.style = "Heading 2"
                     for run in page_header.runs:
                         _set_kannada_font(run)
-                    
+
                     # Save and add page image (smaller size)
                     img_path = os.path.join(temp_dir, f"page_{page_num}.png")
                     # Resize image for document to save space
                     display_img = img.copy()
                     display_img.thumbnail((800, 1200), Image.Resampling.LANCZOS)
                     display_img.save(img_path, "PNG", optimize=True)
-                    
+
                     try:
                         document.add_picture(img_path, width=Inches(4))
                     except Exception as e:
                         logger.warning(f"Could not add image for page {page_num}: {e}")
-                    
+
                     # Add extracted text
                     if cleaned_text.strip():
                         text_para = document.add_paragraph(cleaned_text)
                         for run in text_para.runs:
                             _set_kannada_font(run)
-                        
+
                         full_text += cleaned_text + "\n\n"
                         successful_pages += 1
-                        logger.info(f"Successfully extracted text from page {page_num} ({len(cleaned_text)} chars)")
+                        logger.info(
+                            f"Successfully extracted text from page {page_num} ({len(cleaned_text)} chars)"
+                        )
                     else:
-                        no_text_para = document.add_paragraph("(ಈ ಪುಟದಲ್ಲಿ ಯಾವುದೇ ಪಠ್ಯ ಪತ್ತೆಯಾಗಿಲ್ಲ)")
+                        no_text_para = document.add_paragraph(
+                            "(ಈ ಪುಟದಲ್ಲಿ ಯಾವುದೇ ಪಠ್ಯ ಪತ್ತೆಯಾಗಿಲ್ಲ)"
+                        )
                         for run in no_text_para.runs:
                             _set_kannada_font(run)
                             run.italic = True
                         logger.warning(f"No text extracted from page {page_num}")
-                    
+
                     # Add page break except for last page
                     if page_num < total_pages:
                         document.add_page_break()
-                    
+
                     # Clean up memory after each page
                     del processed_img, display_img
                     gc.collect()
-                        
+
                 except Exception as e:
                     logger.error(f"Error processing page {page_num}: {e}")
                     # Add error message to document
-                    error_para = document.add_paragraph(f"ಪುಟ {page_num} ಸಂಸ್ಕರಣೆಯಲ್ಲಿ ದೋಷ: {str(e)}")
+                    error_para = document.add_paragraph(
+                        f"ಪುಟ {page_num} ಸಂಸ್ಕರಣೆಯಲ್ಲಿ ದೋಷ: {str(e)}"
+                    )
                     for run in error_para.runs:
                         _set_kannada_font(run)
                         run.italic = True
-                    
+
                     if page_num < total_pages:
                         document.add_page_break()
-                    
+
                     # Continue with next page
                     continue
-            
-            logger.info(f"OCR processing completed: {successful_pages}/{processed_pages} pages successful")
-            
+
+            logger.info(
+                f"OCR processing completed: {successful_pages}/{processed_pages} pages successful"
+            )
+
     except Exception as e:
         logger.error(f"Error during OCR processing: {e}")
         # Add error to document instead of raising
@@ -430,7 +479,7 @@ def ocr_pdf_to_word(
     # Final text processing and validation
     if full_text.strip():
         full_text = normalize_unicode(full_text)
-        
+
         # Validate final output
         is_valid, issues = validate_kannada_output(full_text)
         if not is_valid:
@@ -465,3 +514,8 @@ def ocr_pdf_to_word(
         raise
 
     return output_docx_path, output_txt_path
+
+
+def convert_scanned_pdf_to_word(*args, **kwargs):
+    """Backward-compatible alias for :func:`ocr_pdf_to_word`."""
+    return ocr_pdf_to_word(*args, **kwargs)

--- a/modules/pdf_to_word.py
+++ b/modules/pdf_to_word.py
@@ -16,7 +16,7 @@ from .legacy_kannada import (
     detect_legacy_encoding,
     validate_kannada_output,
     normalize_unicode,
-    is_kannada_text
+    is_kannada_text,
 )
 from .hybrid_pdf_detector import detect_pdf_type, extract_images_from_pdf
 
@@ -24,90 +24,101 @@ from .hybrid_pdf_detector import detect_pdf_type, extract_images_from_pdf
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def _detect_legacy_fonts_in_pdf(pdf_path: str) -> bool:
     """Detect if PDF contains legacy Kannada fonts that need conversion."""
     try:
         reader = PdfReader(pdf_path, strict=False)
-        
+
         # Check font names in the PDF
         legacy_font_indicators = [
-            'Nudi', 'BRH', 'Baraha', 'KGP', 'Kedage', 'Malige',
-            'Akshar', 'Hubballi', 'Mallige', 'Sampige', 'Tunga'
+            "Nudi",
+            "BRH",
+            "Baraha",
+            "KGP",
+            "Kedage",
+            "Malige",
+            "Akshar",
+            "Hubballi",
+            "Mallige",
+            "Sampige",
+            "Tunga",
         ]
-        
+
         for page in reader.pages:
-            if '/Font' in page:
-                fonts = page['/Font']
+            if "/Font" in page:
+                fonts = page["/Font"]
                 for font_ref in fonts.values():
-                    if hasattr(font_ref, 'get_object'):
+                    if hasattr(font_ref, "get_object"):
                         font_obj = font_ref.get_object()
-                        if '/BaseFont' in font_obj:
-                            font_name = str(font_obj['/BaseFont'])
+                        if "/BaseFont" in font_obj:
+                            font_name = str(font_obj["/BaseFont"])
                             for indicator in legacy_font_indicators:
                                 if indicator.lower() in font_name.lower():
                                     logger.info(f"Legacy font detected: {font_name}")
                                     return True
-        
+
         return False
-        
+
     except Exception as e:
         logger.warning(f"Could not analyze PDF fonts: {e}")
         return False
+
 
 def _extract_text_with_encoding_detection(pdf_path: str) -> tuple[str, bool]:
     """Extract text and detect encoding issues."""
     extracted_text = ""
     has_legacy_fonts = False
-    
+
     try:
         # First check for legacy fonts
         has_legacy_fonts = _detect_legacy_fonts_in_pdf(pdf_path)
-        
+
         # Try multiple extraction methods
         with pdfplumber.open(pdf_path) as pdf:
             for page_num, page in enumerate(pdf.pages, 1):
                 logger.debug(f"Extracting text from page {page_num}")
-                
+
                 # Primary extraction method
                 page_text = page.extract_text() or ""
-                
+
                 # If no text, try with different layout parameters
                 if not page_text.strip():
-                    page_text = page.extract_text(
-                        layout=True,
-                        x_tolerance=3,
-                        y_tolerance=3
-                    ) or ""
-                
+                    page_text = (
+                        page.extract_text(layout=True, x_tolerance=3, y_tolerance=3)
+                        or ""
+                    )
+
                 if page_text.strip():
                     extracted_text += page_text + "\n\n"
                 else:
                     logger.warning(f"No text extracted from page {page_num}")
-        
+
     except Exception as e:
         logger.error(f"Error extracting text: {e}")
-    
+
     return extracted_text, has_legacy_fonts
+
 
 def _process_extracted_text(text: str, has_legacy_fonts: bool = False) -> str:
     """Process extracted text with comprehensive Kannada handling."""
     if not text.strip():
         return ""
-    
+
     logger.info(f"Processing text (legacy fonts: {has_legacy_fonts})")
     logger.info(f"Sample raw text: '{text[:100]}...'")
-    
+
     # Step 1: Check if text is already good Unicode Kannada
     if is_kannada_text(text) and not has_legacy_fonts:
         logger.info("Text appears to be good Unicode Kannada - minimal processing")
         # Just normalize and clean lightly
         processed = normalize_unicode(text)
-        processed = re.sub(r'\s+', ' ', processed).strip()
+        processed = re.sub(r"\s+", " ", processed).strip()
         return processed
-    
+
     # Step 2: Only apply legacy conversion if fonts detected or text is clearly corrupted
     is_legacy = has_legacy_fonts or detect_legacy_encoding(text)
-    
+
     if is_legacy:
         logger.info("Applying legacy font conversion")
         text = convert_legacy_to_unicode(text)
@@ -116,41 +127,44 @@ def _process_extracted_text(text: str, has_legacy_fonts: bool = False) -> str:
         logger.info("Applying light processing only")
         # Light processing for digital PDFs
         text = normalize_unicode(text)
-        text = re.sub(r'\s+', ' ', text).strip()
-    
+        text = re.sub(r"\s+", " ", text).strip()
+
     # Step 3: Final validation
     is_valid, issues = validate_kannada_output(text)
     if not is_valid:
         logger.warning(f"Text quality issues: {', '.join(issues)}")
-        
+
         # Only try aggressive processing if text is really bad
         if not is_kannada_text(text) and len(text) > 20:
             logger.info("Attempting aggressive processing as fallback")
             text = convert_legacy_to_unicode(text)
             text = post_process_kannada_text(text, is_legacy=True)
-    
+
     logger.info(f"Final processed text sample: '{text[:100]}...'")
     return text
+
 
 def _set_kannada_font(run):
     """Set appropriate font for Kannada text rendering."""
     try:
-        run.font.name = 'Noto Sans Kannada'
+        run.font.name = "Noto Sans Kannada"
         # Fallback fonts for better compatibility
-        run._element.rPr.rFonts.set(qn('w:eastAsia'), 'Noto Sans Kannada')
-        run._element.rPr.rFonts.set(qn('w:cs'), 'Noto Sans Kannada')
+        run._element.rPr.rFonts.set(qn("w:eastAsia"), "Noto Sans Kannada")
+        run._element.rPr.rFonts.set(qn("w:cs"), "Noto Sans Kannada")
     except Exception as e:
         logger.warning(f"Could not set Kannada font: {e}")
+
 
 def _add_page_header(document: Document, page_num: int, total_pages: int):
     """Add a formatted page header."""
     header = document.add_paragraph(f"ಪುಟ {page_num} / {total_pages}")
     header.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
-    header.style = 'Heading 2'
-    
+    header.style = "Heading 2"
+
     # Set Kannada font for header
     for run in header.runs:
         _set_kannada_font(run)
+
 
 def convert_pdf_to_word(
     input_pdf_path: str,
@@ -163,7 +177,7 @@ def convert_pdf_to_word(
     """Convert a digital PDF file to a Word document with enhanced Kannada support."""
 
     logger.info(f"Starting digital PDF conversion: {input_pdf_path}")
-    
+
     # Initialize document
     document = Document()
 
@@ -189,8 +203,10 @@ def convert_pdf_to_word(
 
     # Extract text with encoding detection
     try:
-        raw_text, has_legacy_fonts = _extract_text_with_encoding_detection(input_pdf_path)
-        
+        raw_text, has_legacy_fonts = _extract_text_with_encoding_detection(
+            input_pdf_path
+        )
+
         if not raw_text.strip():
             logger.warning("No text extracted from PDF - might be scanned")
             # Add helpful message to document
@@ -203,33 +219,30 @@ def convert_pdf_to_word(
             for run in warning_para.runs:
                 _set_kannada_font(run)
                 run.bold = True
-            
+
             full_text = no_text_msg
         else:
             # Process the extracted text
             processed_text = _process_extracted_text(raw_text, has_legacy_fonts)
-            
+
             if processed_text.strip():
                 # Add processed text to document
                 text_paragraph = document.add_paragraph(processed_text)
-                
+
                 # Set Kannada font for all runs
                 for run in text_paragraph.runs:
                     _set_kannada_font(run)
-                
+
                 full_text = processed_text
                 logger.info("Text processing completed successfully")
             else:
                 logger.error("Text processing returned empty result")
-                error_msg = (
-                    "ಪಠ್ಯ ಸಂಸ್ಕರಣೆಯಲ್ಲಿ ದೋಷ ಸಂಭವಿಸಿದೆ. "
-                    "PDF ಯಲ್ಲಿ ಪುರಾತನ ಫಾಂಟ್‌ಗಳಿರಬಹುದು."
-                )
+                error_msg = "ಪಠ್ಯ ಸಂಸ್ಕರಣೆಯಲ್ಲಿ ದೋಷ ಸಂಭವಿಸಿದೆ. " "PDF ಯಲ್ಲಿ ಪುರಾತನ ಫಾಂಟ್‌ಗಳಿರಬಹುದು."
                 error_para = document.add_paragraph(error_msg)
                 for run in error_para.runs:
                     _set_kannada_font(run)
                     run.italic = True
-                
+
                 full_text = error_msg
 
     except Exception as e:

--- a/modules/simple_pdf_converter.py
+++ b/modules/simple_pdf_converter.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""Simple PDF to Word conversion utilities using OCR.
+
+This module provides a straightforward interface for converting
+Kannada PDF files to Word documents. It includes an OCR based
+converter that works for both digital PDFs encoded with legacy fonts
+and scanned PDFs that only contain images.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+from typing import Optional
+
+import fitz  # PyMuPDF
+from PIL import Image
+from docx import Document
+
+
+__all__ = [
+    "pdf_to_word_ocr_method",
+    "pdf_to_word_with_ocr",
+    "pdf_to_word_image_based",
+    "setup_word_document_for_kannada",
+    "setup_kannada_font_in_run",
+    "pdf_to_word",
+]
+
+
+def pdf_to_word_ocr_method(file) -> str:
+    """Convert a PDF file handle to a Word document using OCR.
+
+    The returned value is the path to the generated Word file.
+    """
+    try:
+        os.makedirs("static/downloads", exist_ok=True)
+        temp_pdf = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+        file.save(temp_pdf.name)
+        temp_pdf.close()
+
+        output_path = os.path.join("static/downloads", "converted.docx")
+
+        try:
+            if pdf_to_word_with_ocr(temp_pdf.name, output_path):
+                os.unlink(temp_pdf.name)
+                return output_path
+        except Exception:
+            pass
+
+        if pdf_to_word_image_based(temp_pdf.name, output_path):
+            os.unlink(temp_pdf.name)
+            return output_path
+        os.unlink(temp_pdf.name)
+        raise RuntimeError("PDF conversion failed")
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        raise Exception(f"PDF to Word conversion failed: {exc}") from exc
+
+
+def pdf_to_word_with_ocr(pdf_path: str, output_path: str) -> bool:
+    """Convert PDF to Word using OCR (Tesseract)."""
+    try:
+        import pytesseract
+    except Exception:
+        print("pytesseract not available")
+        return False
+
+    try:
+        pytesseract.get_tesseract_version()
+    except Exception:
+        print("Tesseract OCR not installed")
+        return False
+
+    pdf_doc = fitz.open(pdf_path)
+    word_doc = Document()
+    setup_word_document_for_kannada(word_doc)
+
+    try:
+        available = pytesseract.get_languages()  # type: ignore[arg-type]
+        lang = "kan+eng" if "kan" in available else "eng"
+    except Exception:
+        lang = "eng"
+
+    for page_num in range(len(pdf_doc)):
+        page = pdf_doc.load_page(page_num)
+        pix = page.get_pixmap(matrix=fitz.Matrix(3.0, 3.0))
+        img = Image.open(io.BytesIO(pix.tobytes("png")))
+        try:
+            text = pytesseract.image_to_string(
+                img,
+                lang=lang,
+                config="--oem 3 --psm 6",
+            )
+        except Exception as err:
+            print(f"OCR failed for page {page_num+1}: {err}")
+            text = ""
+
+        if text.strip():
+            if page_num > 0:
+                word_doc.add_page_break()
+            for para in text.split("\n\n"):
+                para = para.strip()
+                if para:
+                    run = word_doc.add_paragraph().add_run(para)
+                    setup_kannada_font_in_run(run)
+
+    word_doc.save(output_path)
+    pdf_doc.close()
+    return True
+
+
+def pdf_to_word_image_based(pdf_path: str, output_path: str) -> bool:
+    """Fallback conversion that embeds each PDF page as an image."""
+    try:
+        pdf_doc = fitz.open(pdf_path)
+        word_doc = Document()
+        setup_word_document_for_kannada(word_doc)
+
+        for page_num in range(len(pdf_doc)):
+            page = pdf_doc.load_page(page_num)
+            pix = page.get_pixmap(matrix=fitz.Matrix(2.0, 2.0))
+            img = Image.open(io.BytesIO(pix.tobytes("png")))
+
+            temp_img = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            img.save(temp_img.name, format="PNG")
+            temp_img.close()
+
+            if page_num > 0:
+                word_doc.add_page_break()
+            run = word_doc.add_paragraph().add_run()
+            from docx.shared import Inches
+
+            run.add_picture(temp_img.name, width=Inches(6))
+            os.unlink(temp_img.name)
+
+        word_doc.save(output_path)
+        pdf_doc.close()
+        return True
+    except Exception as err:
+        print(f"Image-based conversion error: {err}")
+        return False
+
+
+def setup_word_document_for_kannada(word_doc: Document) -> None:
+    """Configure default styles for Kannada text."""
+    from docx.oxml.ns import qn
+
+    styles = word_doc.styles
+    default_style = styles["Normal"]
+    font = default_style.font
+    font.name = "Nirmala UI"
+
+    rpr = default_style.element.get_or_add_rPr()
+    rfonts = rpr.get_or_add_rFonts()
+    for key in ("w:ascii", "w:hAnsi", "w:cs", "w:eastAsia"):
+        rfonts.set(qn(key), "Nirmala UI")
+
+
+def setup_kannada_font_in_run(run) -> None:
+    """Apply Kannada font settings to a run."""
+    from docx.oxml.ns import qn
+    from docx.shared import Pt
+
+    run.font.name = "Nirmala UI"
+    run.font.size = Pt(12)
+    rpr = run._element.get_or_add_rPr()
+    rfonts = rpr.get_or_add_rFonts()
+    for key in ("w:ascii", "w:hAnsi", "w:cs", "w:eastAsia"):
+        rfonts.set(qn(key), "Nirmala UI")
+    lang = rpr.get_or_add_lang()
+    lang.set(qn("w:bidi"), "kn-IN")
+
+
+def pdf_to_word(file) -> str:
+    """Public helper that delegates to :func:`pdf_to_word_ocr_method`."""
+    return pdf_to_word_ocr_method(file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,43 +1,44 @@
 # Core Dependencies (NumPy compatibility fix)
-numpy>=1.21.0,<2.0.0
+numpy>=1.26.0,<2.0.0
 
 # Web Framework
-Flask==2.3.3
-Werkzeug==2.3.7
+Flask==3.1.1
+Werkzeug==3.1.3
 
 # PDF Processing
-pdf2image==1.16.3
-pdfplumber==0.10.3
+pdf2image==1.17.0
+pdfplumber==0.11.7
 PyPDF2==3.0.1
+PyMuPDF==1.26.3
 
 # Image Processing and OCR
 opencv-python-headless==4.8.1.78
-Pillow==10.0.1
+Pillow==11.3.0
 pytesseract==0.3.10
 
 # Google Cloud Vision API
-google-auth==2.23.4
-google-auth-httplib2==0.1.1
-google-auth-oauthlib==1.1.0
-google-cloud-vision==3.4.4
+google-auth==2.40.3
+google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.2
+google-cloud-vision==3.10.2
 
 # Document Generation
-lxml==4.9.3
-python-docx==0.8.11
+lxml==6.0.0
+python-docx==1.2.0
 
 # Text Processing and Unicode
 unicodedata2==15.1.0
 
 # Environment Management
-python-dotenv==1.0.0
+python-dotenv==1.1.1
 
 # Logging and Utilities
-colorlog==6.7.0
+colorlog==6.9.0
 
 # Development and Testing (optional)
-black==23.9.1
-flake8==6.1.0
-pytest==7.4.3
+black==25.1.0
+flake8==7.3.0
+pytest==8.4.1
 pytest-flask==1.3.0
 
 # System Requirements


### PR DESCRIPTION
## Summary
- add a simple OCR-based PDF converter for digital and scanned PDFs
- expose the module via `modules.__init__`
- add backwards-compatible alias `convert_scanned_pdf_to_word`
- update requirements for Python 3.12

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a416f80e0833292a62632add2ece1